### PR TITLE
Otimiza cálculo de métricas

### DIFF
--- a/batch_main.sh
+++ b/batch_main.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Função para exibir ajuda do script
+
+# Imprime a função do script
+usage(){
+  echo ""
+  echo "Script para calcular métricas COUNTER em paralelo"
+  echo "================================================="
+  echo "Persiste em disco os resultados obtidos"
+  echo "Arquivos r5_metrics_YYYY-MM-DD contêm os valores das métricas"
+  echo "Arquivos r5_hits_YYYY-MM-DD contêm os acessos (hits) associados às métricas"
+  echo ""
+}
+
+usage_example(){
+  echo "./batch_main.sh" \
+       "-d testing-batch/" \
+       "-u mysql://user:pass@localhost:3306/matomo" \
+       "-s 1 -c scl" \
+       "-p pdf-pid-2021-01-09.data" \
+       "-a issn-acronym-2021-01-09.data" \
+       "-l pid-format-lang-2021-01-09.data" \
+       "-y pid-dates-2021-01-09.data" \
+       "-t 4"
+}
+
+# Imprime uma ajuda sobre o script
+help(){
+  echo ""
+  echo "Uso: $0 -d dir_pretables -u matomo_uri -s id_site -c collection -t threads -p dict_pdf -a dict_acronym -l dict_language -y dict_yop"
+  echo -e "\t-d Diretório com as pré-tabelas"
+  echo -e "\t-u String de conexão com o banco de dados Matomo"
+  echo -e "\t-s ID do site no Matomo"
+  echo -e "\t-c Acrônimo da coleção dos dados das pré-tabelas"
+  echo -e "\t-t Número de processos a serem executados em paralelo"
+  echo -e "\t-p Dicionário PDF --> PID"
+  echo -e "\t-a Dicionário Acrônimo de Periódico --> ISSN"
+  echo -e "\t-l Dicionário PID --> Idioma"
+  echo -e "\t-y Dicionário PID --> Ano de Publicação"
+  echo ""
+  echo "Exemplo:"
+  usage_example
+  exit 1
+}
+
+# Imprime os parâmetros lidos
+print_args(){
+  echo ""
+  echo -e "* Configuração realizada"
+  echo -e "------------------------"
+  echo ""
+  echo -e "* dir_pretables:\t" "$dir_pretables"
+  echo -e "* matomo_uri:\t " "$matomo_uri"
+  echo -e "* id_site:\t " "$id_site"
+  echo -e "* collection:\t " "$collection"
+  echo -e "* threads:\t " "$threads"
+  echo -e "* dict_pdf:\t " "$dict_pdf"
+  echo -e "* dict_acronym:\t " "$dict_acronym"
+  echo -e "* dict_language:\t " "$dict_language"
+  echo -e "* dict_yop:\t " "$dict_yop"
+  echo ""
+}
+
+# Função que cria um semáforo
+open_sem(){
+  mkfifo pipe-$$
+  exec 3<>pipe-$$
+  rm pipe-$$
+  local i=$1
+  for((;i>0;i--)); do
+    printf %s 000 >&3
+  done
+}
+
+# Função auxiliar de semárofo
+run_with_lock(){
+  local x
+  read -u 3 -n 3 x && ((0==x)) || exit $x
+  (
+    ( "$@"; )
+    printf '%.3d' $? >&3
+  )&
+}
+
+# Imprime uso do scritp
+usage
+
+# Lê parâmetros de comando
+while getopts d:u:s:c:t:p:a:l:y: flag
+do
+  case "${flag}" in
+    d) dir_pretables=${OPTARG};;
+    u) matomo_uri=${OPTARG};;
+    s) id_site=${OPTARG};;
+    c) collection=${OPTARG};;
+    t) threads=${OPTARG};;
+    p) dict_pdf=${OPTARG};;
+    a) dict_acronym=${OPTARG};;
+    l) dict_language=${OPTARG};;
+    y) dict_yop=${OPTARG};;
+    ? ) help;;
+  esac
+done
+
+# Checa se argumentos foram preenchidos
+if [ -z "$dir_pretables" ] || [ -z "$matomo_uri" ] || [ -z "$id_site" ] || [ -z "$collection" ] || [ -z "$threads" ] || [ -z "$dict_pdf" ] || [ -z "$dict_acronym" ] || [ -z "$dict_language" ] || [ -z "$dict_yop" ]
+then
+  echo ""
+  echo "WARNING: Faltam argumentos";
+  print_args
+  help
+fi
+
+print_args
+
+# Inicia execução do script
+open_sem $threads
+for f in "$dir_pretables"/*.tsv; do
+  echo ""
+  echo "* Iniciando para arquivo $f"
+  echo ""
+  run_with_lock .venv/bin/python main.py \
+  -c $collection \
+  -i $id_site \
+  --dict_pdf $dict_pdf \
+  --dict_acronym $dict_acronym \
+  --dict_language $dict_language \
+  --dict_yop $dict_yop -u $matomo_uri \
+  --pretables "$f"
+done

--- a/batch_main.sh
+++ b/batch_main.sh
@@ -8,8 +8,9 @@ usage(){
   echo "Script para calcular métricas COUNTER em paralelo"
   echo "================================================="
   echo "Persiste em disco os resultados obtidos"
-  echo "Arquivos r5_metrics_YYYY-MM-DD contêm os valores das métricas"
-  echo "Arquivos r5_hits_YYYY-MM-DD contêm os acessos (hits) associados às métricas"
+  echo "Arquivos r5_metrics_YYYYMMDD contêm os valores das métricas"
+  echo "Arquivos r5_hits_YYYYMMDD contêm os acessos (hits) associados às métricas"
+  echo "Sugere-se t = 5 para um computador com 16 GB de RAM e 6 cores"
   echo ""
 }
 

--- a/counter.py
+++ b/counter.py
@@ -77,22 +77,22 @@ class CounterStat:
             if key not in target:
                 target[key] = {ymd: METRICS_ITEM.copy()}
 
-            target[key][ymd]['total_item_requests'] = self._get_total(
+            target[key][ymd]['total_item_requests'] += self._get_total(
                 datefied_hits[ymd],
                 group_hit_type,
                 group_item_requests)
 
-            target[key][ymd]['total_item_investigations'] = self._get_total(
+            target[key][ymd]['total_item_investigations'] += self._get_total(
                 datefied_hits[ymd],
                 group_hit_type,
                 group_item_investigations)
 
-            target[key][ymd]['unique_item_requests'] = self._get_unique(
+            target[key][ymd]['unique_item_requests'] += self._get_unique(
                 datefied_hits[ymd],
                 group_hit_type,
                 group_item_requests)
 
-            target[key][ymd]['unique_item_investigations'] = self._get_unique(
+            target[key][ymd]['unique_item_investigations'] += self._get_unique(
                 datefied_hits[ymd],
                 group_hit_type,
                 group_item_investigations)

--- a/counter.py
+++ b/counter.py
@@ -68,7 +68,7 @@ class CounterStat:
 
         for ymd in datefied_hits:
             if key not in target:
-                target[key] = {ymd: METRICS_ITEM.copy()}
+                target[key] = {ymd: dicts.counter_item_metrics.copy()}
 
             target[key][ymd]['total_item_requests'] += self._get_total(
                 datefied_hits[ymd],
@@ -89,6 +89,10 @@ class CounterStat:
                 datefied_hits[ymd],
                 group_hit_type,
                 group_item_investigations)
+
+            # Remove valores nulos
+            if sum(target[key][ymd].values()) == 0:
+                del target[key][ymd]
 
     def calculate_metrics(self, data_content):
         """

--- a/counter.py
+++ b/counter.py
@@ -1,13 +1,6 @@
 from utils import dicts
 
 
-# Métricas para Item
-METRICS_ITEM = {'total_item_requests': 0,
-                'unique_item_requests': 0,
-                'total_item_investigations': 0,
-                'unique_item_investigations': 0}
-
-
 class CounterStat:
     """
     Modelo de dados utilizado para representar as métricas COUNTER R5

--- a/counter.py
+++ b/counter.py
@@ -68,7 +68,10 @@ class CounterStat:
 
         for ymd in datefied_hits:
             if key not in target:
-                target[key] = {ymd: dicts.counter_item_metrics.copy()}
+                target[key] = {}
+
+            if ymd not in target[key]:
+                target[key][ymd] = dicts.counter_item_metrics.copy()
 
             target[key][ymd]['total_item_requests'] += self._get_total(
                 datefied_hits[ymd],

--- a/hit.py
+++ b/hit.py
@@ -86,7 +86,7 @@ class HitManager:
     """
     Classe que gerencia objetos Hit
     """
-    def __init__(self, path_pdf_to_pid, issn_to_acronym, pid_to_format_lang, pid_to_yop, flag_include_other_hit_types=False, debug=False):
+    def __init__(self, path_pdf_to_pid, issn_to_acronym, pid_to_format_lang, pid_to_yop, persist_on_database, flag_include_other_hit_types=False):
         self.hits = {'article': {}, 'issue': {}, 'journal': {}, 'platform': {}, 'others': {}}
 
         # Dicionários para tratamento de PID
@@ -102,7 +102,7 @@ class HitManager:
         self.flag_include_other_hit_types = flag_include_other_hit_types
 
         # Utilizada para analisar corretude de lista de Hits e de Métricas
-        self.debug = debug
+        self.persist_on_database = persist_on_database
 
     def _generate_acronym_to_issn(self):
         """

--- a/main.py
+++ b/main.py
@@ -224,6 +224,7 @@ def _export_article(metrics, db_session, collection):
                     db_session.flush()
 
                     existing_localization = new_localization
+
                 try:
                     existing_article_metric = db_tools.get_article_metric(db_session=db_session,
                                                                           year_month_day=ymd,
@@ -255,6 +256,8 @@ def _export_article(metrics, db_session, collection):
                                                                                                                      new_metric_article.fk_article_language_id,
                                                                                                                      new_metric_article.fk_localization_id,
                                                                                                                      new_metric_article.year_month_day))
+                db_session.flush()
+
             except NoResultFound:
                 logging.warning('Nenhum periódico encontrado (ISSN: %s, PID: %s, FMT: %s, LANG: %s)'
                               % (issn, pid, data_format, lang))
@@ -263,7 +266,6 @@ def _export_article(metrics, db_session, collection):
             except IntegrityError as e:
                 db_session.rollback()
                 logging.error('Artigo já está na base ({})'.format(e))
-
     db_session.commit()
 
 

--- a/main.py
+++ b/main.py
@@ -140,8 +140,6 @@ def export_metrics_to_matomo(metrics: dict, db_session, collection: str):
         elif group == 'others':
             _export_others(metrics[group], db_session, collection)
 
-    db_session.commit()
-
 
 def _export_article(metrics, db_session, collection):
     for key, article_data in metrics.items():
@@ -199,7 +197,6 @@ def _export_article(metrics, db_session, collection):
                     existing_article = db_tools.get_article(db_session=db_session,
                                                             pid=pid,
                                                             collection=collection)
-
                 except NoResultFound:
                     # Cria um novo artigo caso artigo não exista na base de dados
                     new_article = Article()
@@ -210,7 +207,6 @@ def _export_article(metrics, db_session, collection):
 
                     db_session.add(new_article)
                     db_session.flush()
-
                     existing_article = new_article
 
                 try:
@@ -228,7 +224,6 @@ def _export_article(metrics, db_session, collection):
                     db_session.flush()
 
                     existing_localization = new_localization
-
                 try:
                     existing_article_metric = db_tools.get_article_metric(db_session=db_session,
                                                                           year_month_day=ymd,
@@ -244,7 +239,6 @@ def _export_article(metrics, db_session, collection):
                                                                                                                      existing_article_metric.fk_article_language_id,
                                                                                                                      existing_article_metric.fk_localization_id,
                                                                                                                      existing_article_metric.year_month_day))
-
                 except NoResultFound:
                     # Cria um novo registro de métrica, caso não exista na base de dados
                     new_metric_article = ArticleMetric()
@@ -255,16 +249,12 @@ def _export_article(metrics, db_session, collection):
                     new_metric_article.year_month_day = ymd
 
                     update_metrics(new_metric_article, article_data[ymd])
-
                     db_session.add(new_metric_article)
                     logging.debug('Adicionada métrica (ART_ID: %s, FMT_ID: %s, LANG_ID: %s, GEO_ID: %s, YMD: %s)' % (new_metric_article.fk_article_id,
                                                                                                                      new_metric_article.fk_article_format_id,
                                                                                                                      new_metric_article.fk_article_language_id,
                                                                                                                      new_metric_article.fk_localization_id,
                                                                                                                      new_metric_article.year_month_day))
-
-                db_session.flush()
-
             except NoResultFound:
                 logging.warning('Nenhum periódico encontrado (ISSN: %s, PID: %s, FMT: %s, LANG: %s)'
                               % (issn, pid, data_format, lang))
@@ -273,6 +263,8 @@ def _export_article(metrics, db_session, collection):
             except IntegrityError as e:
                 db_session.rollback()
                 logging.error('Artigo já está na base ({})'.format(e))
+
+    db_session.commit()
 
 
 def _export_issue(metrics, db_session, collection):

--- a/main.py
+++ b/main.py
@@ -9,12 +9,18 @@ import re
 from counter import CounterStat
 from hit import HitManager
 from socket import inet_ntoa
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from time import time
-from utils import db_tools, dicts, hit_tools as ht
-from utils.sql_declarative import Article, ArticleMetric, Localization, ArticleFormat, ArticleLanguage
-
+from utils import db_tools, dicts, values, hit_tools as ht
+from utils.sql_declarative import (
+    Article,
+    ArticleMetric,
+    Localization,
+    ArticleFormat,
+    ArticleLanguage,
+    Journal,
+    JournalCollection,
+)
 
 MATOMO_DB_IP_COUNTER_LIMIT = int(os.environ.get('MATOMO_DB_IP_COUNTER_LIMIT', '250000'))
 

--- a/persist_on_database.py
+++ b/persist_on_database.py
@@ -1,0 +1,466 @@
+import argparse
+import csv
+import logging
+import os
+import re
+
+from decimal import Decimal
+from utils.regular_expressions import REGEX_ISSN
+from utils import db_tools, values
+from utils.sql_declarative import (
+    Journal,
+    JournalCollection,
+    Localization,
+    ArticleFormat,
+    ArticleLanguage,
+    Article,
+    ArticleMetric
+)
+
+
+COLLECTION_ACRONYM = os.environ.get('COLLECTION_ACRONYM', 'scl')
+
+
+class R5Metrics:
+    def __init__(self, **kargs):
+        self.pid = kargs['pid']
+        self.format_name = kargs['format_name']
+        self.language_name = kargs['language_name']
+        self.latitude = Decimal((kargs['latitude']))
+        self.longitude = Decimal((kargs['longitude']))
+        self.year_of_publication = int(kargs['year_of_publication'])
+        self.issn = kargs['issn']
+        self.year_month_day = kargs['year_month_day']
+        self.total_item_investigations = int(kargs['total_item_investigations'])
+        self.total_item_requests = int(kargs['total_item_requests'])
+        self.unique_item_investigations = int(kargs['unique_item_investigations'])
+        self.unique_item_requests = int(kargs['unique_item_requests'])
+
+
+def sum_metrics(m1, m2):
+    """
+    Retorna uma nova lista com a soma dos elementos de duas listas de métricas
+    :param m1: Lista de métricas 1
+    :param m2: Lista de métricas 2
+    :return: Lista em que cada elemento é a soma dos elementos das listas m1 e m2
+    """
+    return [m1[x] + m2[x] for x in range(4)]
+
+
+def mount_issn_map(session):
+    """
+    Cria mapa de ISSN chave para ISSN valor, com base na banco de dados COUNTER
+    :param session: Sessão de conexão com banco de dados COUNTER
+    :return: Um dicionário que mapeia ISSN-Valor a ISSN-Chave da tabela counter_journal
+    """
+    issn_map = {}
+
+    for j in session.query(Journal):
+        issns = [i for i in [j.pid_issn,
+                 j.online_issn,
+                 j.print_issn] if i != '']
+        for i in issns:
+            if i not in issn_map:
+                issn_map[i] = j.journal_id
+            else:
+                if issn_map[i] != j.journal_id:
+                    logging.error('Base de periódicos está inconsistente (%s -> %s,  %s -> %s)'
+                                  % (i, j.journal_id, i, issn_map[i]))
+
+    return issn_map
+
+
+def mount_localization_map(session):
+    """
+    Cria mapa de (latitude, longitude) para ID de localização na base de dados
+    :param session: Sessão de conexão com banco de dados COUNTER
+    :return: Um dicionário que mapeia (latitude, longitude) a ID de localização
+    """
+    localization_map = {}
+
+    for m in session.query(Localization):
+        localization_map[(m.latitude, m.longitude)] = m.localization_id
+    return localization_map
+
+
+def mount_format_map(session):
+    """
+    Cria mapa de nome de formato para ID de formato na base de dados
+    :param session: Sessão de conexão com banco de dados COUNTER
+    :return: Um dicionário que mapeia nome de formato a ID de formato
+    """
+    format_map = {}
+
+    for m in session.query(ArticleFormat):
+        format_code = m.format_id
+        format_name = m.name
+        format_map[format_name] = format_code
+
+    return format_map
+
+
+def mount_pid_map(session):
+    """
+    Cria mapa de PID e COLLECTION ACRONYM a ID na base de dados
+    :param session: Sessão de conexão com banco de dados COUNTER
+    :return: Um dicionário que mapeia PID e COLLECTION_ACRONYM a ID
+    """
+    pid_map = {}
+
+    for m in session.query(Article):
+        article_id = m.article_id
+        article_pid = m.pid
+        article_collection = m.collection_acronym
+        pid_map[(article_pid, article_collection)] = article_id
+
+    return pid_map
+
+
+def mount_language_map(session):
+    """
+    Cria mapa de nome de idioma para ID de idioma na base de dados
+    :param session: Sessão de conexão com banco de dados COUNTER
+    :return: Um dicionário que mapeia nome de idioma a ID de idioma
+    """
+    language_map = {}
+
+    for m in session.query(ArticleLanguage):
+        language_id = m.language_id
+        language_name = m.name
+        language_map[language_name] = language_id
+
+    return language_map
+
+
+def read_r5_metrics(path_file_r5_metrics):
+    """
+    Processa arquivo r5_metrics para uma lista de instâncias R5Metrics
+    :param path_file_r5_metrics: Caminho de arquivo r5_metrics
+    :return: Lista de instâncias R5Metrics
+    """
+    r5_metrics = []
+    with open(path_file_r5_metrics) as fi:
+        csv_reader = csv.DictReader(fi, delimiter='|', fieldnames=['pid',
+                                                                   'format_name',
+                                                                   'language_name',
+                                                                   'latitude',
+                                                                   'longitude',
+                                                                   'year_of_publication',
+                                                                   'issn',
+                                                                   'year_month_day',
+                                                                   'total_item_investigations',
+                                                                   'total_item_requests',
+                                                                   'unique_item_investigations',
+                                                                   'unique_item_requests'])
+        for row in csv_reader:
+            # Ignora linhas que latitude e longitude são nulas (originárias de IPs locais, por exemplo)
+            if row.get('latitude') != 'NULL' and row.get('longitude') != 'NULL':
+                r5_metrics.append(R5Metrics(**row))
+    return r5_metrics
+
+
+def update_issn_map(r5_metrics, issn_map):
+    """
+    Obtém ISSNs da lista de métricas calculadas
+    :param r5_metrics: lista de instâncias R5Metric
+    :param issn_map: Dicionário que mapeia ISSNs
+    :return: Um dicionário de ISSNs faltantes a serem inseridos na base de dados
+    """
+    new_issns = set()
+    for r in r5_metrics:
+        issn = re.match(REGEX_ISSN, r.issn).string
+        if issn and issn not in issn_map:
+            issn_map[issn] = issn
+            new_issns.add(issn)
+    return new_issns
+
+
+def update_issn_table(issns, db_session):
+    """
+    Atualiza banco de dados COUNTER com novos periódicos
+    :param issns: Lista de ISSNs que não constam no banco de dados
+    :param db_session: Sessão de conexão com banco de dados
+    """
+    logging.info('Há %d periódicos a serem adicionados no banco de dados' % len(issns))
+    for issn in issns:
+        new_journal = Journal()
+        new_journal.pid_issn = issn
+        new_journal.print_issn = ''
+        new_journal.online_issn = ''
+
+        db_session.add(new_journal)
+        db_session.flush()
+
+        new_journal_collection = JournalCollection()
+        new_journal_collection.fk_col_journal_id = new_journal.journal_id
+        new_journal_collection.name = values.DEFAULT_COLLECTION
+        new_journal_collection.title = ''
+
+        db_session.add(new_journal_collection)
+        db_session.flush()
+
+        logging.info('Adicionado periódico %s' % issn)
+    db_session.commit()
+
+
+def update_localization_table(r5_metrics, db_session, localization_map):
+    """
+    Atualiza banco de dados com novas localizações, isto é, pares (latitude, longitude)
+    :param r5_metrics: lista de instâncias R5Metric
+    :param db_session: Sessão de conexão com banco de dados
+    :param localization_map: Dicionário que mapeia (latitude, longitude) a seu respectivo código no banco de dados
+    """
+    all_localizations = set([(r.latitude, r.longitude) for r in r5_metrics])
+    new_localizations = all_localizations.difference(set(localization_map.keys()))
+
+    objects = []
+    for ngeo in new_localizations:
+        latitude, longitude = ngeo
+
+        new_localization = Localization()
+        new_localization.latitude = latitude
+        new_localization.longitude = longitude
+
+        localization_map[(latitude, longitude)] = None
+        objects.append(new_localization)
+
+    db_session.bulk_save_objects(objects)
+    db_session.commit()
+
+    # Recarrega mapa de localização
+    if new_localizations:
+        return True
+
+
+def update_format_table(r5_metrics, db_session, format_map):
+    """
+    Atualiza banco de dados com novos formatos
+    :param r5_metrics: lista de instâncias R5Metric
+    :param db_session: Sessão de conexão com banco de dados
+    :param format_map: Dicionário que mapeia formato a seu respectivo código no banco de dados
+    """
+    all_formats = set([r.format_name for r in r5_metrics])
+    new_formats = all_formats.difference(set(format_map.keys()))
+
+    for nfmt in new_formats:
+        new_fmt = ArticleFormat()
+        new_fmt.name = nfmt
+
+        logging.info('Adicionado formato %s' % nfmt)
+        db_session.add(new_fmt)
+        db_session.commit()
+
+        format_map[new_fmt.name] = new_fmt.format_id
+
+
+def update_language_table(r5_metrics, db_session, language_map):
+    """
+    Atualiza banco de dados com novos idiomas
+    :param r5_metrics: lista de instâncias R5Metric
+    :param db_session: Sessão de conexão com banco de dados
+    :param language_map: Dicionário que mapeia idioma a seu respectivo código no banco de dados
+    """
+    all_languages = set([r.language_name for r in r5_metrics])
+    new_languages = all_languages.difference(set(language_map.keys()))
+
+    for nlang in new_languages:
+        new_language = ArticleLanguage()
+        new_language.name = nlang
+
+        logging.info('Adicionado idioma %s' % nlang)
+        db_session.add(new_language)
+        db_session.commit()
+
+        language_map[new_language.name] = new_language.language_id
+
+
+def update_article_table(r5_metrics, db_session, issn_map, pid_map):
+    """
+    Atualiza banco de dados com novos artigos
+    :param r5_metrics: lista de instâncias R5Metric
+    :param db_session: Sessão de conexão com banco de dados
+    :param issn_map: Dicionário que mapeia ISSNs
+    :param pid_map: Dicionário que mapeia PID e COLLECTION_ACRONYM a código no banco de dados
+    """
+    all_pids = set([(r.pid, COLLECTION_ACRONYM) for r in r5_metrics])
+    new_pids = all_pids.difference(set(pid_map.keys()))
+
+    pid_to_r5 = {}
+    for r in r5_metrics:
+        if (r.pid, COLLECTION_ACRONYM) in new_pids:
+            pid_to_r5[(r.pid, COLLECTION_ACRONYM)] = r
+
+    objects = []
+    for k, v in pid_to_r5.items():
+        pid, col = k
+        if (pid, col) not in pid_map:
+            new_article = Article()
+            new_article.collection_acronym = COLLECTION_ACRONYM
+            new_article.fk_art_journal_id = issn_map[v.issn]
+            new_article.pid = v.pid
+            new_article.yop = v.year_of_publication
+
+            pid_map[(pid, col)] = None
+            objects.append(new_article)
+
+    db_session.bulk_save_objects(objects)
+    db_session.commit()
+
+    # Recarrega mapa de PID e COLLECTION_ACRONYM
+    if new_pids:
+        return True
+
+
+def add_article_metrics(r5_metrics, db_session, maps):
+    """
+    Adiciona métricas de artigo no banco de dados
+    :param r5_metrics: lista de instâncias R5Metric
+    :param db_session: Sessão de conexão com banco de dados
+    :param maps: Dicionários que mapeiam insumos a seus respectivos IDs no banco de dados
+    """
+    objects = []
+    aggregated_metrics = {}
+
+    # Como uma mesma chave ocorre diversas vezes (IPs diferentes podem apontar para uma mesma Localização),
+    #  é preciso agregar os valores das métricas por chave
+    for r in r5_metrics:
+        fk_article_id = maps['pid'][(r.pid, COLLECTION_ACRONYM)]
+        fk_article_language_id = maps['language'][r.language_name]
+        fk_article_format_id = maps['format'][r.format_name]
+        fk_localization_id = maps['localization'][(r.latitude, r.longitude)]
+        year_month_day = r.year_month_day
+
+        # Cria uma chave para a métrica r
+        key = (fk_article_id,
+               fk_article_language_id,
+               fk_article_format_id,
+               fk_localization_id,
+               year_month_day)
+
+        # Adiciona métrica r no dicionário que agrega métricas por key
+        if key not in aggregated_metrics:
+            aggregated_metrics[key] = [r.total_item_investigations,
+                                       r.total_item_requests,
+                                       r.unique_item_investigations,
+                                       r.unique_item_requests]
+
+        else:
+            # Caso key já esteja no dicionário de métricas, faz a somatória dos valores
+            aggregated_metrics[key] = sum_metrics(aggregated_metrics[key], [r.total_item_investigations,
+                                                                            r.total_item_requests,
+                                                                            r.unique_item_investigations,
+                                                                            r.unique_item_requests])
+
+    for key, values in aggregated_metrics.items():
+        art_id, lang_id, fmt_id, geo_id, ymd = key
+        tii, tir, uii, uir = values
+
+        new_metric_article = ArticleMetric()
+        new_metric_article.fk_article_id = art_id
+        new_metric_article.fk_article_format_id = fmt_id
+        new_metric_article.fk_article_language_id = lang_id
+        new_metric_article.fk_localization_id = geo_id
+        new_metric_article.year_month_day = ymd
+        new_metric_article.total_item_investigations = tii
+        new_metric_article.total_item_requests = tir
+        new_metric_article.unique_item_investigations = uii
+        new_metric_article.unique_item_requests = uir
+
+        objects.append(new_metric_article)
+        logging.debug('Adicionada métrica (%s, %s, %s, %s, %s)' % (new_metric_article.fk_article_id,
+                                                                   new_metric_article.fk_article_format_id,
+                                                                   new_metric_article.fk_article_language_id,
+                                                                   new_metric_article.fk_localization_id,
+                                                                   new_metric_article.year_month_day))
+    db_session.bulk_save_objects(objects)
+    db_session.commit()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '-u', '--matomo_db_uri',
+        required=True,
+        dest='matomo_db_uri',
+        help='String de conexão a base SQL Matomo no formato mysql://username:password@host1:port/database'
+    )
+
+    parser.add_argument(
+        '-d', '--dir_r5_metrics',
+        required=True,
+        dest='dir_r5_metrics',
+        help='Diretório com arquivos r5_metrics'
+    )
+
+    params = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO,
+                        format='[%(asctime)s] %(levelname)s %(message)s',
+                        datefmt='%d/%b/%Y %H:%M:%S')
+
+    # Obtém sessão de conexão com banco de dados COUNTER/Matomo
+    db_session = db_tools.get_db_session(params.matomo_db_uri)
+
+    # Obtém dicionários que mapeia ISSN a ISSN-Chave, Idioma a ID e Formato a ID
+    issn_map = mount_issn_map(db_session)
+    localization_map = mount_localization_map(db_session)
+    language_map = mount_language_map(db_session)
+    format_map = mount_format_map(db_session)
+    pid_map = mount_pid_map(db_session)
+
+    # Obtém lista de arquivos r5_metrics a serem lidos
+    files_r5 = sorted([os.path.join(params.dir_r5_metrics, f) for f in os.listdir(params.dir_r5_metrics) if 'r5_metrics' in f])
+    logging.info('Há %d arquivos para serem processados' % len(files_r5))
+
+    # Processa cada arquivo r5_metrics
+    for f in files_r5:
+        logging.info('Processando arquivo %s' % f)
+
+        # Lê arquivo r5
+        logging.info('Convertendo arquivo para R5Metric...')
+        r5_metrics = read_r5_metrics(f)
+
+        # Obtém lista de ISSNs que não existem no banco de dados
+        logging.info('Obtendo ISSNs...')
+        new_issns = update_issn_map(r5_metrics, issn_map)
+
+        # Atualiza banco de dados com ISSNs não encontrados
+        if new_issns:
+            logging.info('Atualizando lista de ISSNs...')
+            update_issn_table(new_issns, db_session)
+
+        # Atualiza lista de pares (Latitude, Longitude) no banco de dados
+        logging.info('Atualizando lista de pares (latitude, longitude)...')
+        exist_new_localizations = update_localization_table(r5_metrics, db_session, localization_map)
+
+        if exist_new_localizations:
+            logging.info('Recarregando dados de localização')
+            localization_map = mount_localization_map(db_session)
+
+        # Atualiza formatos de artigo no banco de dados
+        logging.info('Atualizando formatos...')
+        update_format_table(r5_metrics, db_session, format_map)
+
+        # Atualiza idiomas de artigo no banco de dados
+        logging.info('Atualizando idiomas...')
+        update_language_table(r5_metrics, db_session, language_map)
+
+        # Atualiza artigos no banco de dados
+        logging.info('Atualizando artigos...')
+        exist_new_pids = update_article_table(r5_metrics, db_session, issn_map, pid_map)
+
+        if exist_new_pids:
+            logging.info('Recarregando dados de PID e COLLECTION_ACRONYM')
+            pid_map = mount_pid_map(db_session)
+
+        # Adiciona métricas de artigo no banco de dados
+        logging.info('Adicionando métricas...')
+        add_article_metrics(r5_metrics, db_session, {'pid': pid_map,
+                                                     'language': language_map,
+                                                     'format': format_map,
+                                                     'localization': localization_map})
+
+
+if __name__ == '__main__':
+    main()

--- a/proc/create_dictionaries.py
+++ b/proc/create_dictionaries.py
@@ -172,11 +172,21 @@ def main():
     # PID de artigo para lista de datas
     pid_to_dates = {}
 
-    total_articles = 0
+    mongo_client = mc[MONGO_DATABASE][MONGO_COLLECTION]
+
+    print('Testando conexão... ', end='')
+    is_conection_ok = True if 'code' in mongo_client.find_one().keys() else False
+    if is_conection_ok:
+        print('Sucesso')
+    else:
+        print('Falhou')
+        exit(1)
+
+    total_extracted = 0
     print('Coletando dados...')
-    for article in mc[MONGO_DATABASE][MONGO_COLLECTION].find({}):
-        total_articles += 1
-        print('\r%d de artigos extraídos' % total_articles, end='')
+    for article in mongo_client.find({}):
+        total_extracted += 1
+        print('\rExtraídos: %d' % total_extracted, end='')
 
         pid = article.get('code')
         issns = [i for i in article.get('code_title') if i is not None]

--- a/proc/create_dictionaries.py
+++ b/proc/create_dictionaries.py
@@ -148,6 +148,13 @@ def main():
              'mongodb://username:password@host:port/database.collection'
     )
 
+    parser.add_argument(
+        '-v',
+        default='',
+        dest='version',
+        help='String que representa a versão dos dicionários gerados (usar uma data no formato YYYY-MM-DD)'
+    )
+
     params = parser.parse_args()
 
     try:
@@ -156,6 +163,8 @@ def main():
         print('\nNão foi possível conectar a base de dados do ArticleMeta')
         print(e)
         exit(1)
+
+    version = params.version
 
     # PID de artigo -> lista de ISSNs
     pid_to_issns = {}
@@ -257,20 +266,20 @@ def main():
 
     fix_issn_to_acronym_errors(issn_to_acronym)
 
-    pickle.dump(pid_to_issns, open('pid_to_issns.data', 'wb'))
-    export_pid_to_issn(pid_to_issns, 'pid_to_issns.csv')
+    pickle.dump(pid_to_issns, open('pid-issns-' + version + '.data', 'wb'))
+    export_pid_to_issn(pid_to_issns, 'pid-issns-' + version + '.csv')
 
-    pickle.dump(pid_to_langs, open('pid_to_format_lang.data', 'wb'))
-    export_lang_format_to_pid(pid_to_langs, 'pid_to_format_lang.csv')
+    pickle.dump(pid_to_langs, open('pid-format-lang-' + version + '.data', 'wb'))
+    export_lang_format_to_pid(pid_to_langs, 'pid-format-lang-' + version + '.csv')
 
-    pickle.dump(path_pdf_to_pid, open('path_pdf_to_pid.data', 'wb'))
-    export_path_pdf_to_pid(path_pdf_to_pid, 'path_pdf_to_pid.csv')
+    pickle.dump(path_pdf_to_pid, open('pdf-pid-' + version + '.data', 'wb'))
+    export_path_pdf_to_pid(path_pdf_to_pid, 'pdf-pid-' + version + '.csv')
 
-    pickle.dump(issn_to_acronym, open('issn_to_acronym.data', 'wb'))
-    export_issn_to_acronym(issn_to_acronym, 'issn_to_acronym.csv')
+    pickle.dump(issn_to_acronym, open('issn-acronym-' + version + '.data', 'wb'))
+    export_issn_to_acronym(issn_to_acronym, 'issn-acronym-' + version + '.csv')
 
-    pickle.dump(pid_to_dates, open('pid_to_dates.data', 'wb'))
-    export_pid_to_dates(pid_to_dates, 'pid_to_dates.csv')
+    pickle.dump(pid_to_dates, open('pid-dates-' + version + '.data', 'wb'))
+    export_pid_to_dates(pid_to_dates, 'pid-dates-' + version + '.csv')
 
 
 if __name__ == '__main__':

--- a/proc/populate_journals.py
+++ b/proc/populate_journals.py
@@ -12,10 +12,8 @@ from sqlalchemy.sql import null
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from urllib import parse
 from utils import db_tools, dicts
+from utils.regular_expressions import REGEX_ISSN
 from utils.sql_declarative import Journal, JournalCollection
-
-
-REGEX_ISSN = re.compile(r'[0-9]{4}-[0-9]{3}[0-9xX]')
 
 
 def format_publisher_names(publisher_names: list):

--- a/utils/dicts.py
+++ b/utils/dicts.py
@@ -103,3 +103,11 @@ group_to_item_requests = {
     'journal': mm.COUNTER_JOURNAL_ITEM_REQUESTS,
     'platform': mm.COUNTER_PLATFORM_ITEM_REQUESTS
 }
+
+# métricas COUNTER
+counter_item_metrics = {
+    'total_item_requests': 0,
+    'unique_item_requests': 0,
+    'total_item_investigations': 0,
+    'unique_item_investigations': 0
+}

--- a/utils/regular_expressions.py
+++ b/utils/regular_expressions.py
@@ -10,6 +10,9 @@ REGEX_JOURNAL_PID = r'^[0-9]{4}-[0-9]{3}[0-9xX]$'
 # Detecta ano de publicação (YOP) a partir do PID de artigo
 REGEX_ARTICLE_PID_YOP = r'^S[0-9]{4}-[0-9]{3}[0-9xX](\d{4})\d{9}$'
 
+# Detecta ISSN
+REGEX_ISSN = r'[0-9]{4}-[0-9]{3}[0-9xX]'
+
 # Detectam nome e/ou caminho de arquivo pdf
 REGEX_PDF = r'.*\.pdf$'
 REGEX_ARTICLE_PDF_PATH = r'.*(/pdf/.*/.*)'

--- a/utils/sql_declarative.py
+++ b/utils/sql_declarative.py
@@ -99,6 +99,9 @@ class ArticleMetric(Base):
                                        'year_month_day',
                                        name='uni_art_for_lan_loc_id_ymd'),)
 
+    __table_args__ += (Index('index_ymd',
+                             'year_month_day'),)
+
     __table_args__ += (Index('index_ymd_art_for_id',
                              'fk_article_format_id',
                              'year_month_day'),)
@@ -117,6 +120,13 @@ class ArticleMetric(Base):
                              'fk_article_language_id',
                              'fk_localization_id',
                              'year_month_day'),)
+
+    __table_args__ += (Index('index_ymd_aid_fmt_lang_loc',
+                             'year_month_day',
+                             'fk_article_id',
+                             'fk_article_format_id',
+                             'fk_article_language_id',
+                             'fk_localization_id'),)
 
     metric_id = Column(INTEGER(unsigned=True), primary_key=True, autoincrement=True)
 


### PR DESCRIPTION
Adiciona uma série de modificações que permitem calcular as métricas em paralelo.
A persistência de dados no Matomo continua em modo paralelo, no entanto, também foi otimizada para usar mecanismos de bulk_save_objects do SQLAlchemy.
O processo atual de cálculo de métricas COUNTER envolve quatro passos:

1. Carga de logs no Matomo
2. Extração de pré-tabelas
3. Cálculo de métricas COUNTER
4. Persistência de métricas COUNTER no Matomo

Este PR atua nos itens 3 e 4. 

No item 3, os cálculos podem ser realizados em paralelo, sendo limitante a memória RAM do equipamento. Na prática, é possível calcular os dados de 1 mês em aproximadamente 20 minutos (usando 6 threads e tendo 16GB de RAM disponíveis).

No item 4, é possível persistir em uma hora cerca de 1 mês de métricas.

Na prática, os itens 3 e 4, que antes levavam 18 dias para serem concluídos considerando o cálculo de um ano de dados, agora levam cerca de 18 horas.