### PR TITLE
Melhora conexão com banco de dados Matomo

### DIFF
--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -360,10 +360,9 @@ def extract_pretable(database_uri, date, idsite):
     return engine.execute(raw_query)
 
 
-def get_dates_able_to_extract(database_uri, collection, number_of_days):
+def get_dates_able_to_extract(db_session, collection, number_of_days):
     dates = []
 
-    db_session = get_db_session(database_uri)
     try:
         ds_results = db_session.query(DateStatus).filter(and_(DateStatus.collection == collection,
                                                               DateStatus.status >= DATE_STATUS_LOADED)).order_by(DateStatus.date.desc())

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -131,19 +131,6 @@ def add_foreign_keys_to_table_matomo_log_link_action(matomo_db_uri):
         logging.warning('Chave estrangeira já existe: %s' % sql_foreign_key_idvisit)
 
 
-def get_db_session(matomo_db_uri):
-    """
-    Obtém uma sessão de conexão com base de dados do Matomo
-
-    @param matomo_db_uri: string de conexão à base do Matomo
-    @return: uma sessão de conexão com a base do Matomo
-    """
-    engine = create_engine(matomo_db_uri)
-    Base.metadata.bind = engine
-    db_session = sessionmaker(bind=engine)
-    return db_session()
-
-
 def get_matomo_logs_for_date(db_session, idsite: int, date: datetime.datetime):
     """
     Obtém resultados das tabelas originais de log do Matomo para posterior extração de métricas.

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -356,7 +356,7 @@ def extract_pretable(database_uri, date, idsite):
 
     raw_query = 'SELECT server_time as serverTime, config_browser_name as browserName, config_browser_version as browserVersion, inet_ntoa(conv(hex(location_ip), 16, 10)) as ip, location_latitude as latitude, location_longitude as longitude, name as actionName from matomo_log_link_visit_action LEFT JOIN matomo_log_visit on matomo_log_visit.idvisit = matomo_log_link_visit_action.idvisit LEFT JOIN matomo_log_action on matomo_log_action.idaction = matomo_log_link_visit_action.idaction_url WHERE matomo_log_link_visit_action.idsite = {0} AND server_time >= "{1}" AND server_time < "{2}" ORDER BY ip;'.format(idsite, currente_date, next_date)
 
-    engine = create_engine(database_uri)
+    engine = create_engine(database_uri, pool_recycle=1800)
     return engine.execute(raw_query)
 
 

--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -5,6 +5,8 @@ import logging
 import os
 import re
 import time
+import sys
+sys.path.append(os.getcwd())
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/proc/extract_pretables.py
+++ b/proc/extract_pretables.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import sys
+sys.path.append(os.getcwd())
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/proc/populate_journals.py
+++ b/proc/populate_journals.py
@@ -30,8 +30,10 @@ def format_publisher_names(publisher_names: list):
     @param publisher_names: lista de nomes dos publishers associados a um periódico
     @return: string contendo os nomes dos publishers separados por ponto e vírgula
     """
-    names_without_semicolon = [n.replace(';', ',') for n in publisher_names]
-    return '; '.join(names_without_semicolon)
+    if publisher_names:
+        names_without_semicolon = [n.replace(';', ',') for n in publisher_names]
+        return '; '.join(names_without_semicolon)
+    return ''
 
 
 def format_issn(issn: str):

--- a/proc/populate_journals.py
+++ b/proc/populate_journals.py
@@ -8,6 +8,8 @@ sys.path.append('')
 from articlemeta.client import RestfulClient, ThriftClient
 from sqlalchemy.sql import null
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 from urllib import parse
 from utils import dicts
 from libs import lib_database
@@ -17,6 +19,8 @@ from models.declarative import Journal, JournalCollection
 
 MATOMO_DATABASE_STRING = os.environ.get('MATOMO_DATABASE_STRING', 'mysql://user:pass@localhost:3306/matomo')
 LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'INFO')
+ENGINE = create_engine(MATOMO_DATABASE_STRING, pool_recycle=1800)
+SESSION_FACTORY = sessionmaker(bind=ENGINE)
 
 
 def format_publisher_names(publisher_names: list):
@@ -206,5 +210,4 @@ def main():
     else:
         articlemeta = ThriftClient()
 
-    db_session = lib_database.get_db_session(params.matomodb_uri)
-    populate(articlemeta=articlemeta, db_session=db_session)
+    populate(articlemeta=articlemeta, db_session=SESSION_FACTORY())


### PR DESCRIPTION
Este PR adequa o uso de sessão (via SQLAlchemy) durante toda a aplicação. Isto envolve alterar os principais processos que formam a calculadora COUNTER, a saber: a) extrator de pré-tabelas, b) cálculo de métricas, c) exportador de métricas. Basicamente foi corrigido o modo como uma sessão é utilizada, respeitando o que é indicado em [https://docs.sqlalchemy.org/en/13/orm/session.html](https://docs.sqlalchemy.org/en/13/orm/session.html). 

A partir deste PR, grandes operações receberão uma instância própria para ser usada. E isso impede que a conexão seja perdida com o banco de dados, caso demore uma determinada quantidade de tempo.

Resolve o issue #26.