### PR TITLE
Faz commit toda vez que o bulk de objetos estiver cheio

### DIFF
--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -478,6 +478,12 @@ def persist_metrics(r5_metrics, db_session, maps, key_list, table_class, collect
     return True
 
 
+def _sleep_and_log(seconds):
+    logging.info('Sleeping %d seconds before continue...' % seconds)
+    time.sleep(seconds)
+    logging.info('Continuing')
+
+
 def _aggregate_by_keylist(r5_metrics, key_list, maps):
     """
     Agrega métricas de acordo com uma lista de chaves de agregação

--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -50,6 +50,7 @@ MAX_YEAR = datetime.datetime.now().year + 5
 
 ENGINE = create_engine(MATOMO_DATABASE_STRING, pool_recycle=1800)
 SESSION_FACTORY = sessionmaker(bind=ENGINE)
+SESSION_BULK_LIMIT = int(os.environ.get('SESSION_BULK_LIMIT', '500'))
 
 
 class R5Metrics:

--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -529,6 +529,7 @@ def _aggregate_by_keylist(r5_metrics, key_list, maps):
 
 
 def _dump_repairing_data(year_month_day, keys):
+    logging.error('It was not possible to persist metrics. Dumping repairing data %s' % year_month_day)
     repair_file_path = os.path.join(DIR_R5_METRICS_TO_REPAIR,
                                     COLLECTION + '.csv')
     with open(repair_file_path, 'a') as file:

--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -394,6 +394,9 @@ def persist_metrics(r5_metrics, db_session, maps, key_list, table_class, collect
     # Obtém um dicionário de métricas agregadas pelos valores associados a chave de key_list
     aggregated_metrics = _aggregate_by_keylist(r5_metrics, key_list, maps)
 
+    # Data das métricas
+    year_month_day = r5_metrics[0].year_month_day
+
     # Obtém último ID
     try:
         last_id = lib_database.get_last_id(db_session, table_class)


### PR DESCRIPTION
Este PR adiciona um tratamento para evitar erro de falta de memória. Na prática adiciona uma variável que controla quantos objetos estão para ser persistidos. Ao atingir o tamanho máximo permitido, persiste os dados e esvazia o bulk.