### PR TITLE
Corrige situação em que arquivo de métrics r5 está vazio

### DIFF
--- a/proc/export_to_database.py
+++ b/proc/export_to_database.py
@@ -389,6 +389,10 @@ def persist_metrics(r5_metrics, db_session, maps, key_list, table_class, collect
     :param table_class: Classe que representa a tabela a ser persistida
     :param collection: acrônimo da coleção
     """
+    # Retorna Trua caso não existam dados a serem gravados
+    if len(r5_metrics) == 0:
+        return True
+
     objects = []
 
     # Obtém um dicionário de métricas agregadas pelos valores associados a chave de key_list


### PR DESCRIPTION
Adiciona um tratamento para impedir que ocorra o erro `IndexError: list index out of range` ao encontrar um arquivo de métricas r5 vazio. Esse arquivo pode estar vazio ao não existirem acessos contabilizados para um determinado dia, situação que é recorrente na coleção `nbr` para datas prévias ao dia 24 de maio de 2021.