### PR TITLE
Adiciona parâmetro para tornar opcional a gravação de Hits em disco

### DIFF
--- a/models/hit.py
+++ b/models/hit.py
@@ -222,11 +222,9 @@ class HitManager:
 
         if not hit.has_valid_format():
             hit.valid = False
-            return
 
         if hit.pid not in self.pid_to_format_lang.get(hit.collection, {}):
             hit.valid = False
-            return
 
         hit.content_type = lib_hit.get_content_type_new_url(hit)
         hit.hit_type = lib_hit.get_hit_type_new_url(hit.action_name.lower())

--- a/models/hit.py
+++ b/models/hit.py
@@ -128,7 +128,7 @@ class HitManager:
         # Flag para incluir na contagem outros tipos de Hit (Issue, Journal, Platform)
         self.flag_include_other_hit_types = flag_include_other_hit_types
 
-        # Utilizada para analisar corretude de lista de Hits e de Métricas
+        # Salve dados de métricas diretamente no banco de dados
         self.persist_on_database = persist_on_database
 
         # Salva dados de Hit no disco

--- a/models/hit.py
+++ b/models/hit.py
@@ -112,7 +112,7 @@ class HitManager:
     """
     Classe que gerencia objetos Hit
     """
-    def __init__(self, path_pdf_to_pid, issn_to_acronym, pid_to_format_lang, pid_to_yop, persist_on_database, flag_include_other_hit_types=False):
+    def __init__(self, path_pdf_to_pid, issn_to_acronym, pid_to_format_lang, pid_to_yop, persist_on_database, persist_hits_on_disk, flag_include_other_hit_types=False):
         self.hits = {'article': {}, 'issue': {}, 'journal': {}, 'platform': {}, 'others': {}}
 
         # Dicionários para tratamento de PID
@@ -130,6 +130,9 @@ class HitManager:
 
         # Utilizada para analisar corretude de lista de Hits e de Métricas
         self.persist_on_database = persist_on_database
+
+        # Salva dados de Hit no disco
+        self.persist_hits_o_disk = persist_hits_on_disk
 
     def _generate_acronym_to_issn(self):
         """

--- a/proc/calculate_metrics.py
+++ b/proc/calculate_metrics.py
@@ -489,7 +489,8 @@ def run_counter_routines(hit_manager: HitManager, db_session, collection, file_p
         export_metrics_to_matomo(metrics=cs.metrics, db_session=db_session, collection=collection, pid_to_issn=hit_manager.pid_to_issn)
 
     logging.info('Salvando hits em disco...')
-    export_article_hits_to_csv(hit_manager.hits['article'], file_prefix, hit_manager.pid_to_issn)
+    if hit_manager.persist_hits_o_disk:
+        export_article_hits_to_csv(hit_manager.hits['article'], file_prefix, hit_manager.pid_to_issn)
 
     logging.info('Salvando métricas em disco...')
     export_article_metrics_to_csv(cs.metrics['article'], file_prefix, hit_manager.pid_to_issn)
@@ -538,6 +539,14 @@ def main():
         action='store_true',
         default=False,
         help='Também persiste resultados em banco de dados'
+    )
+
+    parser.add_argument(
+        '--persist_hits_on_disk',
+        dest='persist_hits_on_disk',
+        action='store_true',
+        default=False,
+        help='Grava Hits em disco'
     )
 
     parser.add_argument(
@@ -599,6 +608,7 @@ def main():
                              pid_to_format_lang=maps['pid-format-lang'],
                              pid_to_yop=maps['pid-dates'],
                              persist_on_database=params.persist_on_database,
+                             persist_hits_on_disk=params.persist_hits_on_disk,
                              flag_include_other_hit_types=params.include_other_hit_types)
 
     if params.use_pretables:


### PR DESCRIPTION
Permite que um parâmetro seja informado para gravar ou não Hits em disco.
A solução é necessária para que não sejam armazenados, de forma automática, subprodutos do processo de cálculo de métricas em disco. E isso evita que disco seja consumido de maneira desnecessária.