### PR TITLE
Corrige agregação por coleção

### DIFF
--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -353,7 +353,7 @@ def extract_aggregated_data_for_article_language_year_month(database_uri, collec
         unique_item_requests = unique_item_requests + VALUES(unique_item_requests),
         unique_item_investigations = unique_item_investigations + VALUES(unique_item_investigations)
     ;
-    '''.format(date, collection)
+    '''.format(collection, date)
     engine = create_engine(database_uri)
     return engine.execute(raw_query)
 
@@ -402,7 +402,7 @@ def extract_aggregated_data_for_journal_language_year_month(database_uri, collec
         unique_item_requests = unique_item_requests + VALUES(unique_item_requests),
         unique_item_investigations = unique_item_investigations + VALUES(unique_item_investigations)
     ;
-    '''.format(date, collection)
+    '''.format(collection, date)
     engine = create_engine(database_uri)
     return engine.execute(raw_query)
 
@@ -438,7 +438,7 @@ def get_aggregated_data_for_journal_geolocation_year_month(database_uri, collect
         cl.id,
         ym
     ;
-    '''.format(date, collection)
+    '''.format(collection, date)
     engine = create_engine(database_uri)
 
     return engine.execute(raw_query)

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -420,21 +420,19 @@ def get_aggregated_data_for_journal_geolocation_year_month(database_uri, collect
         sum(cam.unique_item_investigations) AS uii
     FROM
         counter_article_metric cam
-    LEFT JOIN
+    JOIN
         counter_article ca ON ca.id = cam.idarticle
-    LEFT JOIN
-        counter_journal cj ON cj.id = ca.idjournal_a
-    LEFT JOIN
-        counter_journal_collection cjc ON cjc.idjournal_jc = cj.id
-    LEFT JOIN
-        counter_localization cl ON cam.idlocalization = cl.id 
+    JOIN
+        counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a
+    JOIN
+        counter_localization cl ON cl.id = cam.idlocalization
     WHERE
-        year_month_day = '{0}' AND
-        cjc.collection = '{1}'
+        ca.collection = cjc.collection AND
+        cjc.collection = '{0}' AND
+        cam.year_month_day = '{1}'
     GROUP BY
-        cjc.collection,
-        cj.id,
-        cl.id,
+        cjc.id,
+        cam.idlocalization,
         ym
     ;
     '''.format(collection, date)

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -373,7 +373,7 @@ def extract_aggregated_data_for_journal_language_year_month(database_uri, collec
         )
         SELECT
             cjc.collection,
-            cj.id,
+            cjc.idjournal_jc,
             cam.idlanguage,
             substr(cam.year_month_day, 1, 7) AS ym,
             sum(cam.total_item_requests) AS tir,
@@ -382,18 +382,17 @@ def extract_aggregated_data_for_journal_language_year_month(database_uri, collec
             sum(cam.unique_item_investigations) AS uii
         FROM
             counter_article_metric cam
-        LEFT JOIN
+        JOIN
             counter_article ca ON ca.id = cam.idarticle
-        LEFT JOIN
-            counter_journal cj ON cj.id = ca.idjournal_a
-        LEFT JOIN
-            counter_journal_collection cjc ON cjc.idjournal_jc = cj.id
+        JOIN
+            counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a
         WHERE
-            year_month_day = '{0}' AND
-            cjc.collection = '{1}'
+            cjc.collection = '{0}' AND
+            cjc.collection = ca.collection AND
+            year_month_day = '{1}'
         GROUP BY
             cjc.collection,
-            cj.id,
+            cjc.idjournal_jc,
             cam.idlanguage,
             ym
     ON DUPLICATE KEY UPDATE

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -410,7 +410,8 @@ def get_aggregated_data_for_journal_geolocation_year_month(database_uri, collect
     raw_query = '''
     SELECT
         cjc.collection,
-        cj.id,
+        cjc.idjournal_jc as journalID,
+        cjc.id as journalCollectionID,
         cl.latitude,
         cl.longitude,
         substr(cam.year_month_day, 1, 7) AS ym,
@@ -453,7 +454,7 @@ def update_aggr_journal_geolocation(db_session, data):
                 AggrJournalGeolocationYearMonthMetric.year_month == year_month,
                 AggrJournalGeolocationYearMonthMetric.country_code == country_code)
             ).one()
-        
+
             aggr_jou_geo.total_item_requests += tir
             aggr_jou_geo.total_item_investigations += tii
             aggr_jou_geo.unique_item_requests += uir
@@ -469,9 +470,9 @@ def update_aggr_journal_geolocation(db_session, data):
             aggr_jou_geo.total_item_requests = tir
             aggr_jou_geo.unique_item_investigations = uii
             aggr_jou_geo.unique_item_requests = uir
-            
+
             db_session.add(aggr_jou_geo)
-        
+
         except OperationalError as e:
             logging.error(e)
 

--- a/libs/lib_database.py
+++ b/libs/lib_database.py
@@ -334,15 +334,14 @@ def extract_aggregated_data_for_article_language_year_month(database_uri, collec
             sum(cam.unique_item_investigations) AS uii
         FROM
             counter_article_metric cam
-        LEFT JOIN
+        JOIN
             counter_article ca ON ca.id = cam.idarticle
-        LEFT JOIN
-            counter_journal cj ON cj.id = ca.idjournal_a
-        LEFT JOIN
-            counter_journal_collection cjc ON cjc.idjournal_jc = cj.id
+        JOIN
+            counter_journal_collection cjc ON cjc.idjournal_jc = ca.idjournal_a
         WHERE
-            year_month_day = '{0}' AND
-            cjc.collection = '{1}'
+            cjc.collection = '{0}' AND
+            cjc.collection = ca.collection AND
+            year_month_day = '{1}'
         GROUP BY
             ca.collection,
             cam.idarticle,

--- a/proc/aggregate.py
+++ b/proc/aggregate.py
@@ -53,7 +53,7 @@ def _translate_geolocation_to_country(data):
         if geo_reversed:
             country_code = geo_reversed.pop().get('country_code', '')
 
-            key = (d.collection, d.id, d.ym, country_code)
+            key = (d.collection, d.journalID, d.ym, country_code)
 
             if key not in translated_data:
                 translated_data[key] = [0, 0, 0, 0]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 
 setup(
     name="scielo-usage-counter",
-    version='0.5.0',
+    version='0.5.1',
     description="The SciELO COUNTER Tools",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",


### PR DESCRIPTION
Este PR corrige algumas queries utilizadas para agregar dados por:
1. coleção - periódico - idioma
2. coleção - artigo - idioma
3. coleção - periódico - geolocalização

As queries e os métodos corrigidos resolvem a situação em que um periódico está em mais de um coleção. Cada coleção/site conta apenas seus próprios acessos. A camada mais externa da aplicação, por meio das procedures, faz a somatória desses valores, quando oportuno.